### PR TITLE
Add shared invocation utils

### DIFF
--- a/bot_finder_app/app.py
+++ b/bot_finder_app/app.py
@@ -1,6 +1,7 @@
 import streamlit as st
 
 from embedding_utils import load_index, search
+from invocation_utils import build_suggested_invocation
 
 st.set_page_config(page_title="Bot Finder")
 
@@ -21,6 +22,9 @@ if query:
         desc = bot_data.get('description') or bot_data.get('shortDescription') or ''
         if desc:
             st.write(desc)
+        suggestion = build_suggested_invocation(query, bot_id, bot_data)
+        if suggestion:
+            st.caption(f"Suggested Invocation: {suggestion}")
         for m in matches:
             kind = m.get('kind', 'example')
             if kind == 'app_description':

--- a/invocation_utils.py
+++ b/invocation_utils.py
@@ -1,0 +1,56 @@
+import os
+
+try:
+    import openai
+except Exception:  # pragma: no cover - optional dependency
+    openai = None
+
+def extract_options(query: str):
+    """Return (question, options) parsed from the user query."""
+    if not query:
+        return query, None
+    if "?" in query:
+        q_part, rest = query.split("?", 1)
+        question = q_part.strip() + "?"
+        parts = [p.strip() for p in rest.split(",") if p.strip()]
+        if len(parts) >= 2:
+            return question, parts
+        return question, None
+    return query.strip(), None
+
+
+def generate_options(question: str):
+    """Use OpenAI to generate poll options or return defaults."""
+    if openai and os.getenv("OPENAI_API_KEY"):
+        try:
+            resp = openai.chat.completions.create(
+                model="gpt-3.5-turbo",
+                messages=[
+                    {
+                        "role": "system",
+                        "content": "Generate two short poll options separated by commas.",
+                    },
+                    {"role": "user", "content": question},
+                ],
+                max_tokens=20,
+            )
+            text = resp.choices[0].message.content.strip()
+            opts = [o.strip(" -") for o in text.replace("\n", ",").split(",") if o.strip()]
+            if len(opts) >= 2:
+                return opts[:2]
+        except Exception:
+            pass
+    return ["Yes", "No"]
+
+
+def build_suggested_invocation(query: str, bot_id: str, bot_data: dict) -> str | None:
+    """Return a suggested invocation string for the given query and bot."""
+    if not query:
+        return None
+    question, options = extract_options(query)
+    if not options:
+        options = generate_options(question)
+    bot_name = bot_data.get("name", bot_id)
+    mention = f"@{bot_name}".replace("  ", " ").strip()
+    invocation = f"{mention} {question} {', '.join(options)}"
+    return invocation

--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -9,6 +9,7 @@ sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
 import streamlit as st
 
 from bot_finder_app.embedding_utils import load_index, search
+from invocation_utils import build_suggested_invocation
 
 
 @st.cache_resource(show_spinner=False)
@@ -121,6 +122,8 @@ def filter_by_notification(bot_ids: list, option: str) -> list:
     return filtered
 
 
+
+
 st.set_page_config(page_title="Teams Bot Explorer", layout="wide")
 
 if "selected_bot" not in st.session_state:
@@ -209,6 +212,13 @@ with col_right:
             for cmd in commands:
                 with st.expander(cmd["title"]):
                     st.write(cmd["description"] or "No description")
+
+        suggestion = build_suggested_invocation(
+            st.session_state.get("msg_query", ""), bot_id, bot_data
+        )
+        if suggestion:
+            st.subheader("Suggested Invocation")
+            st.code(suggestion)
 
         examples = bot_data.get("examplePrompts") or []
         if examples:


### PR DESCRIPTION
## Summary
- share `build_suggested_invocation` helper for bot apps
- show Suggested Invocation in Bot Finder view
- keep Streamlit app using the shared helper

## Testing
- `pip install -r streamlit_app/requirements.txt` *(fails: large downloads)*
- `python3 -m py_compile streamlit_app/app.py`
- `python3 -m py_compile bot_finder_app/app.py`
- `python3 -m py_compile invocation_utils.py`


------
https://chatgpt.com/codex/tasks/task_e_687561c62fac83278158a00e1a525480