### PR TITLE
Respect scope when suggesting bot command invocations

### DIFF
--- a/bot_finder_app/app.py
+++ b/bot_finder_app/app.py
@@ -22,7 +22,7 @@ if query:
         desc = bot_data.get('description') or bot_data.get('shortDescription') or ''
         if desc:
             st.write(desc)
-        suggestion = build_suggested_invocation(query, bot_id, bot_data)
+        suggestion = build_suggested_invocation(query, bot_id, bot_data, None)
         if suggestion:
             st.caption(f"Suggested Invocation: {suggestion}")
         else:

--- a/streamlit_app/app.py
+++ b/streamlit_app/app.py
@@ -214,7 +214,10 @@ with col_right:
                     st.write(cmd["description"] or "No description")
 
         suggestion = build_suggested_invocation(
-            st.session_state.get("msg_query", ""), bot_id, bot_data
+            st.session_state.get("msg_query", ""),
+            bot_id,
+            bot_data,
+            st.session_state.get("scope_filter", []),
         )
         if suggestion:
             st.subheader("Suggested Invocation")


### PR DESCRIPTION
## Summary
- filter command titles by scope in `build_suggested_invocation`
- pass the selected scope filter from the Streamlit UI
- adjust basic bot finder app to pass `None`

## Testing
- `python -m py_compile invocation_utils.py streamlit_app/app.py bot_finder_app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_6875a41197dc8327ad680ccbf7fb44bd